### PR TITLE
Add auth signup and login operations to GateKit node

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ npm install n8n-nodes-gatekit
 
 ### Auth
 
+- **auth signup** - Create a new user account (first user becomes admin)
+- **auth login** - Login with email and password
 - **auth whoami** - Get current authentication context and permissions
 
 ### ApiKeys

--- a/nodes/GateKit/GateKit.node.ts
+++ b/nodes/GateKit/GateKit.node.ts
@@ -313,6 +313,32 @@ export class GateKit implements INodeType {
         },
         options: [
           {
+          name: 'Signup',
+          value: 'signup',
+          action: 'Create a new user account (first user becomes admin)',
+          description: 'Create a new user account (first user becomes admin)',
+          routing: {
+            request: {
+              method: 'POST',
+              url: '=/api/v1/auth/signup',
+              body: {},
+            },
+          },
+        },
+          {
+          name: 'Login',
+          value: 'login',
+          action: 'Login with email and password',
+          description: 'Login with email and password',
+          routing: {
+            request: {
+              method: 'POST',
+              url: '=/api/v1/auth/login',
+              body: {},
+            },
+          },
+        },
+          {
           name: 'Whoami',
           value: 'whoami',
           action: 'Get current authentication context and permissions',
@@ -326,8 +352,113 @@ export class GateKit implements INodeType {
           },
         }
         ],
-        default: 'whoami',
+        default: 'signup',
       },
+      {
+            displayName: 'Email address',
+            name: 'email',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['auth'],
+                operation: ['signup'],
+              },
+            },
+            routing: {
+              request: {
+                qs: {
+                  'email': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+            displayName: 'Password (min 8 chars, 1 uppercase, 1 number)',
+            name: 'password',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['auth'],
+                operation: ['signup'],
+              },
+            },
+            routing: {
+              request: {
+                qs: {
+                  'password': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+            displayName: 'Full name',
+            name: 'name',
+            type: 'string',
+            required: false,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['auth'],
+                operation: ['signup'],
+              },
+            },
+            routing: {
+              request: {
+                qs: {
+                  'name': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+            displayName: 'Email address',
+            name: 'email',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['auth'],
+                operation: ['login'],
+              },
+            },
+            routing: {
+              request: {
+                qs: {
+                  'email': '={{$value}}',
+                },
+              },
+            },
+          },
+      {
+            displayName: 'Password',
+            name: 'password',
+            type: 'string',
+            required: true,
+            default: "",
+            
+            displayOptions: {
+              show: {
+                resource: ['auth'],
+                operation: ['login'],
+              },
+            },
+            routing: {
+              request: {
+                qs: {
+                  'password': '={{$value}}',
+                },
+              },
+            },
+          },
       {
         displayName: 'Operation',
         name: 'operation',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-gatekit",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "n8n community node for GateKit universal messaging gateway",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

Added authentication operations to enable user signup and login directly from n8n workflows.

**Version**: v
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New operations**:
  -  - Create new user account (first user becomes admin)
  -  - Login with email and password
- **Form parameters**:
  - Email address field (required for both operations)
  - Password field with validation hints for signup
  - Full name field (optional for signup)
- **Updated README** with new operation documentation

### Workflow Impact

Workflows can now:
- Create GateKit accounts programmatically
- Authenticate users and obtain JWT tokens
- Handle complete user onboarding flows within n8n
- Support multi-tenant scenarios with proper admin setup
