### PR TITLE
Add GateKitTrigger node for webhook events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './dist/nodes/GateKit/GateKit.node';
+export * from './dist/nodes/GateKitTrigger/GateKitTrigger.node';
 export * from './dist/credentials/GateKitApi.credentials';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-gatekit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "n8n community node for GateKit universal messaging gateway",
   "keywords": [
     "n8n-community-node-package",
@@ -37,7 +37,8 @@
       "dist/credentials/GateKitApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/GateKit/GateKit.node.js"
+      "dist/nodes/GateKit/GateKit.node.js",
+      "dist/nodes/GateKitTrigger/GateKitTrigger.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds the new **GateKitTrigger** node to enable webhook-based automation workflows in n8n.

**Version**: v1.4.0  
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New Node**:  for receiving webhook events
- **Export Added**: Expose GateKitTrigger node in package exports
- **Node Registration**: Added to n8n node configuration
- **Version Bump**: 1.3.0 → 1.4.0

### Workflow Impact

The new trigger node enables users to:

- **Receive webhook events** from GateKit messaging platforms (Discord, Telegram, WhatsApp)
- **Trigger workflows** automatically when messages are received
- **Build reactive automation** that responds to incoming messages in real-time
- **Create chatbots and automated responses** across multiple messaging platforms

This complements the existing GateKit action node, providing complete bidirectional messaging automation capabilities within n8n's visual workflow builder.
