### PR TITLE
Add GateKit Trigger node with webhook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ dist/
 coverage/
 .env
 .env.local
-credentials/
-nodes/
-package/

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,3 @@
 export * from './dist/nodes/GateKit/GateKit.node';
+export * from './dist/nodes/GateKitTrigger/GateKitTrigger.node';
 export * from './dist/credentials/GateKitApi.credentials';

--- a/nodes/GateKitTrigger/GateKitTrigger.node.json
+++ b/nodes/GateKitTrigger/GateKitTrigger.node.json
@@ -1,0 +1,21 @@
+{
+  "node": "n8n-nodes-gatekit.GateKitTrigger",
+  "nodeVersion": "1.0",
+  "codexVersion": "1.0",
+  "categories": [
+    "Communication",
+    "Trigger"
+  ],
+  "resources": {
+    "credentialDocumentation": [
+      {
+        "url": "https://docs.gatekit.dev/authentication"
+      }
+    ],
+    "primaryDocumentation": [
+      {
+        "url": "https://docs.gatekit.dev/webhooks"
+      }
+    ]
+  }
+}

--- a/nodes/GateKitTrigger/GateKitTrigger.node.ts
+++ b/nodes/GateKitTrigger/GateKitTrigger.node.ts
@@ -1,0 +1,267 @@
+import {
+  IHookFunctions,
+  IWebhookFunctions,
+  INodeType,
+  INodeTypeDescription,
+  IWebhookResponseData,
+} from 'n8n-workflow';
+
+export class GateKitTrigger implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'GateKit Trigger',
+    name: 'gateKitTrigger',
+    icon: 'file:gatekit.svg',
+    group: ['trigger'],
+    version: 1,
+    description: 'Triggers workflow when messages are received via GateKit',
+    defaults: {
+      name: 'GateKit Trigger',
+    },
+    inputs: [],
+    outputs: ['main'],
+    credentials: [
+      {
+        name: 'GateKitApi',
+        required: true,
+      },
+    ],
+    webhooks: [
+      {
+        name: 'default',
+        httpMethod: 'POST',
+        responseMode: 'onReceived',
+        path: 'webhook',
+      },
+    ],
+    properties: [
+      {
+        displayName: 'Project ID',
+        name: 'projectId',
+        type: 'string',
+        default: 'default',
+        required: true,
+        description: 'The GateKit project ID to monitor for messages',
+      },
+      {
+        displayName: 'Events',
+        name: 'events',
+        type: 'multiOptions',
+        options: [
+          {
+            name: 'Message Received',
+            value: 'message.received',
+            description: 'Trigger when a message is received',
+          },
+          {
+            name: 'Message Sent',
+            value: 'message.sent',
+            description: 'Trigger when a message is sent successfully',
+          },
+          {
+            name: 'Message Failed',
+            value: 'message.failed',
+            description: 'Trigger when a message fails to send',
+          },
+          {
+            name: 'Button Clicked',
+            value: 'button.clicked',
+            description: 'Trigger when a button is clicked',
+          },
+          {
+            name: 'Reaction Added',
+            value: 'reaction.added',
+            description: 'Trigger when a reaction is added to a message',
+          },
+          {
+            name: 'Reaction Removed',
+            value: 'reaction.removed',
+            description: 'Trigger when a reaction is removed from a message',
+          },
+        ],
+        default: ['message.received'],
+        required: true,
+        description: 'The events to subscribe to',
+      },
+      {
+        displayName: 'Webhook Name',
+        name: 'webhookName',
+        type: 'string',
+        default: 'n8n Webhook',
+        description: 'Name to identify this webhook in GateKit dashboard',
+      },
+    ],
+  };
+
+  webhookMethods = {
+    default: {
+      async checkExists(this: IHookFunctions): Promise<boolean> {
+        const webhookData = this.getWorkflowStaticData('node');
+        const credentials = await this.getCredentials('GateKitApi');
+
+        if (webhookData.webhookId === undefined) {
+          return false;
+        }
+
+        const projectId = this.getNodeParameter('projectId') as string;
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          const response = await this.helpers.request({
+            method: 'GET',
+            url: `${apiUrl}/api/v1/projects/${projectId}/webhooks/${webhookData.webhookId}`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+            },
+            json: true,
+          });
+
+          return !!response;
+        } catch (error: any) {
+          if (error.statusCode === 404 || error.response?.status === 404) {
+            delete webhookData.webhookId;
+            delete webhookData.webhookSecret;
+            delete webhookData.events;
+            return false;
+          }
+          throw error;
+        }
+      },
+
+      async create(this: IHookFunctions): Promise<boolean> {
+        const webhookUrl = this.getNodeWebhookUrl('default') as string;
+        const credentials = await this.getCredentials('GateKitApi');
+        const projectId = this.getNodeParameter('projectId') as string;
+        const events = this.getNodeParameter('events', []) as string[];
+        const webhookName = this.getNodeParameter('webhookName', 'n8n Webhook') as string;
+
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        if (webhookUrl.includes('//localhost')) {
+          throw new Error(
+            'The Webhook cannot work on "localhost". Please setup n8n on a custom domain or start with "--tunnel"!'
+          );
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          const response = await this.helpers.request({
+            method: 'POST',
+            url: `${apiUrl}/api/v1/projects/${projectId}/webhooks`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+              'Content-Type': 'application/json',
+            },
+            body: {
+              url: webhookUrl,
+              events: events,
+              name: webhookName,
+              // Let GateKit auto-generate a secure secret
+            },
+            json: true,
+          });
+
+          if (!response || !response.id) {
+            throw new Error('Invalid response from GateKit API: missing webhook ID');
+          }
+
+          const webhookData = this.getWorkflowStaticData('node');
+          webhookData.webhookId = response.id;
+          webhookData.webhookSecret = response.secret; // Store secret for HMAC validation
+          webhookData.events = events;
+
+          return true;
+        } catch (error: any) {
+          throw new Error(`Failed to create GateKit webhook: ${error.message || String(error)}`);
+        }
+      },
+
+      async delete(this: IHookFunctions): Promise<boolean> {
+        const webhookData = this.getWorkflowStaticData('node');
+        const credentials = await this.getCredentials('GateKitApi');
+        const projectId = this.getNodeParameter('projectId') as string;
+
+        if (!projectId) {
+          throw new Error('Project ID is required');
+        }
+
+        if (webhookData.webhookId === undefined) {
+          return true;
+        }
+
+        const apiUrl = credentials.apiUrl as string;
+
+        try {
+          await this.helpers.request({
+            method: 'DELETE',
+            url: `${apiUrl}/api/v1/projects/${projectId}/webhooks/${webhookData.webhookId}`,
+            headers: {
+              'X-API-Key': credentials.apiKey as string,
+            },
+            json: true,
+          });
+
+          delete webhookData.webhookId;
+          delete webhookData.webhookSecret;
+          delete webhookData.events;
+
+          return true;
+        } catch (error: any) {
+          // Webhook might already be deleted
+          if (error.statusCode === 404 || error.response?.status === 404) {
+            delete webhookData.webhookId;
+            delete webhookData.webhookSecret;
+            delete webhookData.events;
+            return true;
+          }
+          throw error;
+        }
+      },
+    },
+  };
+
+  async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+    const bodyData = this.getBodyData();
+    const headers = this.getHeaderData();
+
+    // Validate HMAC signature for security (GateKit format: sha256=<hash>)
+    const webhookData = this.getWorkflowStaticData('node');
+    const signatureHeader = headers['x-gatekit-signature'] as string;
+    const timestamp = headers['x-gatekit-timestamp'] as string;
+
+    // If we have a secret stored, signature validation is required
+    if (webhookData.webhookSecret) {
+      if (!signatureHeader || !timestamp) {
+        throw new Error('Missing webhook signature or timestamp');
+      }
+
+      const crypto = require('crypto');
+
+      // GateKit signature format: timestamp.body
+      const signedPayload = `${timestamp}.${JSON.stringify(bodyData)}`;
+      const expectedSignature = crypto
+        .createHmac('sha256', webhookData.webhookSecret)
+        .update(signedPayload)
+        .digest('hex');
+
+      // Extract signature (format: "sha256=<hash>")
+      const signature = signatureHeader.replace('sha256=', '');
+
+      if (signature !== expectedSignature) {
+        throw new Error('Invalid webhook signature - possible security attack');
+      }
+    }
+
+    // Process the webhook payload from GateKit
+    // The payload structure depends on the event type
+    return {
+      workflowData: [this.helpers.returnJsonArray([bodyData])],
+    };
+  }
+}

--- a/nodes/GateKitTrigger/gatekit.svg
+++ b/nodes/GateKitTrigger/gatekit.svg
@@ -1,0 +1,5 @@
+<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+  <rect width="60" height="60" rx="12" fill="#6366f1"/>
+  <text x="30" y="35" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">GK</text>
+  <circle cx="45" cy="15" r="5" fill="#10b981"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-gatekit",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "n8n community node for GateKit universal messaging gateway",
   "keywords": [
     "n8n-community-node-package",
@@ -37,7 +37,8 @@
       "dist/credentials/GateKitApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/GateKit/GateKit.node.js"
+      "dist/nodes/GateKit/GateKit.node.js",
+      "dist/nodes/GateKitTrigger/GateKitTrigger.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds a new GateKit Trigger node that enables webhook-based workflow automation, allowing n8n workflows to respond to real-time events from messaging platforms.

**Version**: v1.3.1
**Source**: [GateKit Backend](https://github.com/filipexyz/gatekit)

### Changes

- **New GateKit Trigger Node**: Complete trigger node implementation with webhook lifecycle management
- **Multi-Event Support**: Subscribe to message.received, message.sent, message.failed, button.clicked, reaction events
- **Security Features**: HMAC SHA-256 signature validation for webhook authenticity
- **Auto-Management**: Automatic webhook creation, validation, and cleanup on workflow activation/deactivation
- **Export Updates**: Added trigger node to package exports and n8n node registry
- **Repository Cleanup**: Fixed .gitignore to include necessary directories (credentials/, nodes/, package/)

### Workflow Impact

The trigger node unlocks powerful real-time automation capabilities:

- **Instant Response**: Workflows trigger immediately when messages arrive
- **Multi-Platform**: Works with Discord, Telegram, WhatsApp via single webhook
- **Event Filtering**: Choose specific events to respond to (received, sent, failed, interactions)
- **Secure Integration**: Built-in signature validation prevents unauthorized triggers

### Technical Implementation

- Full webhook lifecycle: automatic registration, health checks, and cleanup
- Project-scoped webhooks with secure credential management
- Error handling for network issues and API changes
- n8n-compliant node structure with proper metadata and documentation
